### PR TITLE
Adding environment variables to ProcessKeywords

### DIFF
--- a/keywords/java/step-library-commons/src/main/java/ch/exense/step/library/commons/AbstractProcessKeyword.java
+++ b/keywords/java/step-library-commons/src/main/java/ch/exense/step/library/commons/AbstractProcessKeyword.java
@@ -108,7 +108,7 @@ public abstract class AbstractProcessKeyword extends AbstractEnhancedKeyword {
         // ManagedProcess doesn't expose a constructor accepting the cmd as string and allowing to specify the execution directory.
         // We're therefore force to duplicate the tokenize method of ManagedProcess
         // TODO: Release a new version of ManagedProcess accepting cmd as string and allowing to specify the execution directory.
-        ManagedProcess process = new ManagedProcess("ExecuteCommand", tokenize(cmd), workingDirectory, workingDirectory, true);
+        ManagedProcess process = new ManagedProcess("ExecuteCommand", tokenize(cmd), workingDirectory, workingDirectory, true, environment);
         executeManagedCommand(timeoutMs, outputConfiguration, postProcess, process,null);
     }
 

--- a/keywords/java/step-library-commons/src/main/java/ch/exense/step/library/commons/AbstractProcessKeyword.java
+++ b/keywords/java/step-library-commons/src/main/java/ch/exense/step/library/commons/AbstractProcessKeyword.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -86,22 +87,22 @@ public abstract class AbstractProcessKeyword extends AbstractEnhancedKeyword {
     }
 
     protected void executeManagedCommand(String cmd, int timeoutMs) throws Exception {
-        executeManagedCommand(cmd, timeoutMs, new OutputConfiguration(), null);
+        executeManagedCommand(cmd, Map.of(), timeoutMs, new OutputConfiguration(), null);
     }
 
-    protected void executeManagedCommand(String cmd, int timeoutMs, OutputConfiguration outputConfiguration) throws Exception {
-        executeManagedCommand(cmd, timeoutMs, outputConfiguration, null);
+    protected void executeManagedCommand(String cmd, Map<String,String> environment, int timeoutMs, OutputConfiguration outputConfiguration) throws Exception {
+        executeManagedCommand(cmd, environment, timeoutMs, outputConfiguration, null);
     }
 
-    protected void executeManagedCommand(List<String> cmd, int timeoutMs, OutputConfiguration outputConfiguration, Consumer<ManagedProcess> postProcess) throws Exception {
+    protected void executeManagedCommand(List<String> cmd, Map<String,String> environment, int timeoutMs, OutputConfiguration outputConfiguration, Consumer<ManagedProcess> postProcess) throws Exception {
         // The method retrieveAndExtractAutomationPackage returns null if we're not in the context of an AP. In this case the managed process
         // uses the default settings for the log and execution directory
         File workingDirectory = retrieveAndExtractAutomationPackage();
-        ManagedProcess process = new ManagedProcess("ExecuteCommand", cmd, workingDirectory, workingDirectory, true);
+        ManagedProcess process = new ManagedProcess("ExecuteCommand", cmd, workingDirectory, workingDirectory, true, environment);
         executeManagedCommand(timeoutMs, outputConfiguration, postProcess, process, null);
     }
 
-    protected void executeManagedCommand(String cmd, int timeoutMs, OutputConfiguration outputConfiguration, Consumer<ManagedProcess> postProcess) throws Exception {
+    protected void executeManagedCommand(String cmd, Map<String,String> environment, int timeoutMs, OutputConfiguration outputConfiguration, Consumer<ManagedProcess> postProcess) throws Exception {
         // The method retrieveAndExtractAutomationPackage returns null if we're not in the context of an AP. In this case the managed process
         // uses the default settings for the log and execution directory
         File workingDirectory = retrieveAndExtractAutomationPackage();

--- a/keywords/java/step-library-kw-monitoring-system/src/main/java/ch/exense/step/library/kw/monitoring/TypePerfKeywords.java
+++ b/keywords/java/step-library-kw-monitoring-system/src/main/java/ch/exense/step/library/kw/monitoring/TypePerfKeywords.java
@@ -50,7 +50,7 @@ public class TypePerfKeywords extends AbstractProcessKeyword {
 	@Keyword(name = "Typeperf", schema = "{\"properties\":{}}")
 	public void getTypePerf() throws Exception {
 		String cmd = buildCommandLine();
-		executeManagedCommand(cmd, DEFAULT_PROCESS_TIMEOUT, new OutputConfiguration(false, 1000, 10000, true, true), p -> {
+		executeManagedCommand(cmd, Map.of(), DEFAULT_PROCESS_TIMEOUT, new OutputConfiguration(false, 1000, 10000, true, true), p -> {
 			try {
 				executionPostProcess(p.getProcessOutputLog());
 			} catch (Exception e) {

--- a/keywords/java/step-library-kw-monitoring-system/src/main/java/ch/exense/step/library/kw/monitoring/WindowsServiceStatusKeywords.java
+++ b/keywords/java/step-library-kw-monitoring-system/src/main/java/ch/exense/step/library/kw/monitoring/WindowsServiceStatusKeywords.java
@@ -17,6 +17,7 @@ package ch.exense.step.library.kw.monitoring;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Map;
 
 import ch.exense.step.library.commons.AbstractProcessKeyword;
 import step.handlers.javahandler.Keyword;
@@ -26,7 +27,7 @@ public class WindowsServiceStatusKeywords extends AbstractProcessKeyword {
 	@Keyword(name = "Windows_Service_Status", schema = "{\"properties\":{\"Service_Display_Name\":{\"type\":\"string\"}},\"required\":[\"Service_Display_Name\"]}")
 	public void getWindowsServiceStatus() throws Exception {
 		String cmd = buildCommandLine();
-		executeManagedCommand(cmd, DEFAULT_PROCESS_TIMEOUT, new OutputConfiguration(false, 1000, 10000, true, true), p->{
+		executeManagedCommand(cmd, Map.of(), DEFAULT_PROCESS_TIMEOUT, new OutputConfiguration(false, 1000, 10000, true, true), p->{
 			try {
 				executionPostProcess(p.getProcessOutputLog());
 			} catch (Exception e) {

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/JavaProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/JavaProcessKeywords.java
@@ -16,6 +16,7 @@
 package ch.exense.step.library.kw.system;
 
 import step.handlers.javahandler.Keyword;
+import java.util.Map;
 
 public class JavaProcessKeywords extends ProcessKeywords {
 
@@ -35,7 +36,7 @@ public class JavaProcessKeywords extends ProcessKeywords {
 	public void executeJavaProcess() throws Exception {
 		readInputs();
 		String command = buildCommandLine();
-		executeManagedCommand(command, timeoutInMillis, outputConfiguration);
+		executeManagedCommand(command, Map.of(), timeoutInMillis, outputConfiguration);
 	}
 
 	protected String buildCommandLine() {

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
@@ -18,6 +18,7 @@ package ch.exense.step.library.kw.system;
 import ch.exense.commons.io.FileHelper;
 import ch.exense.commons.processes.ManagedProcess;
 import ch.exense.step.library.commons.AbstractProcessKeyword;
+import com.fasterxml.jackson.databind.util.LinkedNode;
 import org.apache.commons.io.filefilter.PathMatcherFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import step.grid.io.Attachment;
@@ -49,6 +50,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			"        \"type\": \"string\"\n" +
 			"      }\n" +
 			"    }";
+
 	protected String command;
 	protected Map<String,String> environments;
 	protected int timeoutInMillis;
@@ -165,11 +167,20 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 		}
 	}
 
+	// the list of properties to remove from the env. variables
+	private static final List<String> LIST_JAVA_PROPERTIES = List.of("currentReport","controllerSettings",
+			"report","currentArtefact");
 	protected void readInputs() {
 		command = input.getString(COMMAND,"");
 
 		if (input.getBoolean(ENVIRONMENT_VARIABLES,false)) {
-			environments = properties;
+			environments = properties.entrySet().stream()
+					.filter(entry ->
+							!entry.getKey().startsWith("##") &&
+							!entry.getKey().startsWith("$") &&
+							!entry.getKey().startsWith("plugins.") &&
+							!LIST_JAVA_PROPERTIES.contains(entry.getKey()))
+					.collect(Collectors.toMap(Map.Entry::getKey,Map.Entry::getValue));
 		} else {
 			environments = new HashMap<>();
 		}

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
@@ -31,15 +31,14 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected static final String COMMAND = "Command";
+	private static final String ENVIRONMENT_VARIABLES = "Environments";
 	protected static final String MAX_OUTPUT_ATTACHMENT_SIZE = "Max_Output_Attachment_Size";
 	protected static final String MAX_OUTPUT_PAYLOAD_SIZE = "Max_Output_Payload_Size";
 	protected static final String CHECK_EXIT_CODE = "Check_Exit_Code";
@@ -50,8 +49,8 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			"        \"type\": \"string\"\n" +
 			"      }\n" +
 			"    }";
-
 	protected String command;
+	protected Map<String,String> environments;
 	protected int timeoutInMillis;
 	protected OutputConfiguration outputConfiguration;
 	
@@ -59,18 +58,20 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to start a generic process.")
 	public void executeSystemCommand() throws Exception {
 		readInputs();
-		executeManagedCommand(command, timeoutInMillis, outputConfiguration);
+		executeManagedCommand(command, environments, timeoutInMillis, outputConfiguration);
 	}
 	
 	@Keyword(name = "ExecuteBash", schema = "{\"properties\":{\"" + TIMEOUT_MS + "\":{\"type\":\"string\"},"
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a bash command.")
@@ -83,7 +84,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 		cmd.add(command);
 
 		Consumer<ManagedProcess> managedProcessConsumer = getManagedProcessConsumer();
-		executeManagedCommand(cmd, timeoutInMillis, outputConfiguration, managedProcessConsumer);
+		executeManagedCommand(cmd, environments, timeoutInMillis, outputConfiguration, managedProcessConsumer);
 	}
 	
 
@@ -91,6 +92,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a windows cmd command.")
@@ -103,7 +105,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 		cmd.add(command);
 
 		Consumer<ManagedProcess> managedProcessConsumer = getManagedProcessConsumer();
-		executeManagedCommand(cmd, timeoutInMillis, outputConfiguration, managedProcessConsumer);
+		executeManagedCommand(cmd, environments, timeoutInMillis, outputConfiguration, managedProcessConsumer);
 	}
 
 	private Consumer<ManagedProcess> getManagedProcessConsumer() {
@@ -165,6 +167,18 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected void readInputs() {
 		command = input.getString(COMMAND,"");
+		List<String> tmp_env = Arrays.stream(input.getJsonArray(ENVIRONMENT_VARIABLES).toArray())
+						.map(Object::toString).collect(Collectors.toList());
+
+		environments = new HashMap<>();
+		for (String env : tmp_env) {
+			String[] kv = env.split("=");
+			if (kv.length==1) {
+				environments.put(kv[0],"");
+			} else {
+				environments.put(kv[0],kv[1]);
+			}
+		}
 		timeoutInMillis = Integer.parseInt(input.getString(TIMEOUT_MS, Integer.toString(DEFAULT_PROCESS_TIMEOUT)));
 		outputConfiguration = readOutputConfiguration();
 	}

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
@@ -18,7 +18,6 @@ package ch.exense.step.library.kw.system;
 import ch.exense.commons.io.FileHelper;
 import ch.exense.commons.processes.ManagedProcess;
 import ch.exense.step.library.commons.AbstractProcessKeyword;
-import com.fasterxml.jackson.databind.util.LinkedNode;
 import org.apache.commons.io.filefilter.PathMatcherFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import step.grid.io.Attachment;
@@ -39,7 +38,7 @@ import java.util.stream.Collectors;
 public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected static final String COMMAND = "Command";
-	protected static final String ENVIRONMENT_VARIABLES = "Properties_As_Env";
+	protected static final String PROPERTIES_AS_ENVIRONMENT_VARIABLES = "Pass_Properties_As_Env_Variables";
 	protected static final String MAX_OUTPUT_ATTACHMENT_SIZE = "Max_Output_Attachment_Size";
 	protected static final String MAX_OUTPUT_PAYLOAD_SIZE = "Max_Output_Payload_Size";
 	protected static final String CHECK_EXIT_CODE = "Check_Exit_Code";
@@ -60,7 +59,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
-			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
+			+ PROPERTIES_AS_ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to start a generic process.")
@@ -73,7 +72,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
-			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
+			+ PROPERTIES_AS_ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a bash command.")
@@ -94,7 +93,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
-			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
+			+ PROPERTIES_AS_ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a windows cmd command.")
@@ -173,7 +172,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 	protected void readInputs() {
 		command = input.getString(COMMAND,"");
 
-		if (input.getBoolean(ENVIRONMENT_VARIABLES,false)) {
+		if (input.getBoolean(PROPERTIES_AS_ENVIRONMENT_VARIABLES,false)) {
 			environments = properties.entrySet().stream()
 					.filter(entry ->
 							!entry.getKey().startsWith("##") &&

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected static final String COMMAND = "Command";
-	private static final String ENVIRONMENT_VARIABLES = "Environments";
+	private static final String ENVIRONMENT_VARIABLES = "Properties_As_Env";
 	protected static final String MAX_OUTPUT_ATTACHMENT_SIZE = "Max_Output_Attachment_Size";
 	protected static final String MAX_OUTPUT_PAYLOAD_SIZE = "Max_Output_Payload_Size";
 	protected static final String CHECK_EXIT_CODE = "Check_Exit_Code";
@@ -58,7 +58,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
-			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
+			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to start a generic process.")
@@ -71,7 +71,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
-			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
+			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a bash command.")
@@ -92,7 +92,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
 			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
-			+ ENVIRONMENT_VARIABLES + "\": " + SCHEMA_ARRAY_STRING + ","
+			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
 			description="Keyword used to run a windows cmd command.")
@@ -167,18 +167,13 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected void readInputs() {
 		command = input.getString(COMMAND,"");
-		List<String> tmp_env = Arrays.stream(input.getJsonArray(ENVIRONMENT_VARIABLES).toArray())
-						.map(Object::toString).collect(Collectors.toList());
 
-		environments = new HashMap<>();
-		for (String env : tmp_env) {
-			String[] kv = env.split("=");
-			if (kv.length==1) {
-				environments.put(kv[0],"");
-			} else {
-				environments.put(kv[0],kv[1]);
-			}
+		if (input.getBoolean(ENVIRONMENT_VARIABLES,false)) {
+			environments = properties;
+		} else {
+			environments = new HashMap<>();
 		}
+
 		timeoutInMillis = Integer.parseInt(input.getString(TIMEOUT_MS, Integer.toString(DEFAULT_PROCESS_TIMEOUT)));
 		outputConfiguration = readOutputConfiguration();
 	}

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/ProcessKeywords.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public class ProcessKeywords extends AbstractProcessKeyword {
 
 	protected static final String COMMAND = "Command";
-	private static final String ENVIRONMENT_VARIABLES = "Properties_As_Env";
+	protected static final String ENVIRONMENT_VARIABLES = "Properties_As_Env";
 	protected static final String MAX_OUTPUT_ATTACHMENT_SIZE = "Max_Output_Attachment_Size";
 	protected static final String MAX_OUTPUT_PAYLOAD_SIZE = "Max_Output_Payload_Size";
 	protected static final String CHECK_EXIT_CODE = "Check_Exit_Code";
@@ -57,7 +57,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 	@Keyword(name = "Execute", schema = "{\"properties\":{\"" + TIMEOUT_MS + "\":{\"type\":\"string\"},"
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
-			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
 			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
@@ -70,7 +70,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 	@Keyword(name = "ExecuteBash", schema = "{\"properties\":{\"" + TIMEOUT_MS + "\":{\"type\":\"string\"},"
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
-			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
 			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,
@@ -91,7 +91,7 @@ public class ProcessKeywords extends AbstractProcessKeyword {
 	@Keyword(name = "ExecuteCmd", schema = "{\"properties\":{\"" + TIMEOUT_MS + "\":{\"type\":\"string\"},"
 			+ "\"" + MAX_OUTPUT_PAYLOAD_SIZE + "\":{\"type\":\"string\"},\""
 			+ MAX_OUTPUT_ATTACHMENT_SIZE + "\":{\"type\":\"string\"},\""
-			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},"
+			+ CHECK_EXIT_CODE + "\":{\"type\":\"boolean\"},\""
 			+ ENVIRONMENT_VARIABLES + "\":{\"type\":\"boolean\"},"
 			+ "\"" + COMMAND + "\":{\"type\":\"string\"}, \"" + ARTIFACTS + "\": " + SCHEMA_ARRAY_STRING + "},\"required\":[\"" + COMMAND + "\"]}",
 			timeout = 1800000,

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +42,7 @@ public class ProcessKeywordsTest {
 
 	@Before
 	public void setUp() {
-		ctx = KeywordRunner.getExecutionContext(ProcessKeywords.class);
+		ctx = KeywordRunner.getExecutionContext(Map.of("Password","glop"),ProcessKeywords.class);
 	}
 
 	@After
@@ -113,6 +114,23 @@ public class ProcessKeywordsTest {
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(1, attachments.size());
 		assertFirstAttachment(attachments);
+	}
+
+	@Test
+	public void testEnvironment() throws Exception {
+		// set the env variables
+		JsonObject input = Json.createObjectBuilder().add("Command", "echo $Password").add("Properties_As_Env", true)
+				.build();
+		Output<JsonObject> output = ctx.run("ExecuteBash", input.toString());
+
+		assertTrue(output.getPayload().getString("stdout").startsWith("glop"));
+
+		// DO NOT set the env variables
+		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Properties_As_Env", false)
+				.build();
+		output = ctx.run("ExecuteBash", input.toString());
+
+		assertTrue(output.getPayload().getString("stdout").equals("\n"));
 	}
 
 	private static String executeCommandKeyword() {

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
@@ -38,6 +38,9 @@ import static org.junit.Assert.assertTrue;
 
 public class ProcessKeywordsTest {
 
+	private static final String COMMAND_KEYWORD = executeCommandKeyword();
+	private static final String ECHO_ENV_PASSWORD = "echo " + setEnvVariableSyntax("Password");
+	private static final String UNRESOLVED_ENV_VARIABLE_VALUE = setEnvVariableSyntax("Password") + "\n";
 	private ExecutionContext ctx;
 
 	@Before
@@ -109,7 +112,7 @@ public class ProcessKeywordsTest {
 	public void testArtifacts() throws Exception {
 		JsonObject input = Json.createObjectBuilder().add("Command", "(echo test)>test.log")
 				.add("Artifacts", Json.createArrayBuilder().add("test.log").build()).build();
-		Output<JsonObject> output = ctx.run(executeCommandKeyword(), input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(1, attachments.size());
@@ -122,38 +125,43 @@ public class ProcessKeywordsTest {
 
 		ctx = KeywordRunner.getExecutionContext(Map.of("Password","glop"),ProcessKeywords.class);
 		// set the env variables
-		JsonObject input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", true)
+		JsonObject input = Json.createObjectBuilder().add("Command", ECHO_ENV_PASSWORD).add("Pass_Properties_As_Env_Variables", true)
 				.build();
-		Output<JsonObject> output = ctx.run("ExecuteBash", input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
+		System.out.println(output.getPayload());
 		assertTrue(output.getPayload().getString("stdout").startsWith("glop"));
 
 		// DO NOT set the env variables
-		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", false)
+		input = Json.createObjectBuilder().add("Command", ECHO_ENV_PASSWORD).add("Pass_Properties_As_Env_Variables", false)
 				.build();
-		output = ctx.run("ExecuteBash", input.toString());
+		output = ctx.run(COMMAND_KEYWORD, input.toString());
 
-		assertTrue(output.getPayload().getString("stdout").equals("\n"));
+		assertTrue(output.getPayload().getString("stdout").equals(UNRESOLVED_ENV_VARIABLE_VALUE));
 
 		// with no properties - Pass_Properties_As_Env_Variables = false
 		ctx = old_ctx;
 
-		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", false)
+		input = Json.createObjectBuilder().add("Command", ECHO_ENV_PASSWORD).add("Pass_Properties_As_Env_Variables", false)
 				.build();
-		output = ctx.run("ExecuteBash", input.toString());
+		output = ctx.run(COMMAND_KEYWORD, input.toString());
 
-		assertTrue(output.getPayload().getString("stdout").equals("\n"));
+		assertTrue(output.getPayload().getString("stdout").equals(UNRESOLVED_ENV_VARIABLE_VALUE));
 
 		// with no properties - Pass_Properties_As_Env_Variables = true
-		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", true)
+		input = Json.createObjectBuilder().add("Command", ECHO_ENV_PASSWORD).add("Pass_Properties_As_Env_Variables", true)
 				.build();
-		output = ctx.run("ExecuteBash", input.toString());
+		output = ctx.run(COMMAND_KEYWORD, input.toString());
 
-		assertTrue(output.getPayload().getString("stdout").equals("\n"));
+		assertTrue(output.getPayload().getString("stdout").equals(UNRESOLVED_ENV_VARIABLE_VALUE));
 	}
 
 	private static String executeCommandKeyword() {
 		return isWindows() ? "ExecuteCmd" : "ExecuteBash";
+	}
+	
+	private static String setEnvVariableSyntax(String enVariable) {
+		return isWindows() ? String.format("%%%s%%", enVariable): String.format("$%s", enVariable) ;
 	}
 
 	public static boolean isWindows() {
@@ -179,7 +187,7 @@ public class ProcessKeywordsTest {
 	public void testArtifacts2() throws Exception {
 		JsonObject input = Json.createObjectBuilder().add("Command", "(echo test)>test.log")
 				.add("Artifacts", Json.createArrayBuilder().add("test.log").add("test.log").build()).build();
-		Output<JsonObject> output = ctx.run(executeCommandKeyword(), input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(2, attachments.size());
@@ -190,7 +198,7 @@ public class ProcessKeywordsTest {
 	public void testArtifactsWithRegex() throws Exception {
 		JsonObject input = Json.createObjectBuilder().add("Command", "(echo test)>test1.log && (echo test)>test2.log")
 				.add("Artifacts", Json.createArrayBuilder().add("test.*").build()).build();
-		Output<JsonObject> output = ctx.run(executeCommandKeyword(), input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(2, attachments.size());
@@ -202,7 +210,7 @@ public class ProcessKeywordsTest {
 	public void testArtifactsAsDirectory() throws Exception {
 		JsonObject input = Json.createObjectBuilder().add("Command", "mkdir test && (echo test)>test/test.log")
 				.add("Artifacts", Json.createArrayBuilder().add("test").build()).build();
-		Output<JsonObject> output = ctx.run(executeCommandKeyword(), input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(1, attachments.size());
@@ -223,7 +231,7 @@ public class ProcessKeywordsTest {
 		tempFile.toFile().deleteOnExit();
 		JsonObject input = Json.createObjectBuilder().add("Command", "(echo test)>" + tempFile)
 				.add("Artifacts", Json.createArrayBuilder().add(tempFile.toString()).build()).build();
-		Output<JsonObject> output = ctx.run(executeCommandKeyword(), input.toString());
+		Output<JsonObject> output = ctx.run(COMMAND_KEYWORD, input.toString());
 
 		List<Attachment> attachments = output.getAttachments();
 		assertEquals(1, attachments.size());

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
@@ -40,7 +40,7 @@ public class ProcessKeywordsTest {
 
 	private static final String COMMAND_KEYWORD = executeCommandKeyword();
 	private static final String ECHO_ENV_PASSWORD = "echo " + setEnvVariableSyntax("Password");
-	private static final String UNRESOLVED_ENV_VARIABLE_VALUE = setEnvVariableSyntax("Password") + "\n";
+	private static final String UNRESOLVED_ENV_VARIABLE_VALUE = setEnvVariableOutput("Password") + "\n";
 	private ExecutionContext ctx;
 
 	@Before
@@ -162,6 +162,10 @@ public class ProcessKeywordsTest {
 	
 	private static String setEnvVariableSyntax(String enVariable) {
 		return isWindows() ? String.format("%%%s%%", enVariable): String.format("$%s", enVariable) ;
+	}
+	
+	private static String setEnvVariableOutput(String enVariable) {
+		return isWindows() ? String.format("%%%s%%", enVariable): "" ;
 	}
 
 	public static boolean isWindows() {

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/ProcessKeywordsTest.java
@@ -42,7 +42,7 @@ public class ProcessKeywordsTest {
 
 	@Before
 	public void setUp() {
-		ctx = KeywordRunner.getExecutionContext(Map.of("Password","glop"),ProcessKeywords.class);
+		ctx = KeywordRunner.getExecutionContext(ProcessKeywords.class);
 	}
 
 	@After
@@ -118,15 +118,34 @@ public class ProcessKeywordsTest {
 
 	@Test
 	public void testEnvironment() throws Exception {
+		ExecutionContext old_ctx = ctx;
+
+		ctx = KeywordRunner.getExecutionContext(Map.of("Password","glop"),ProcessKeywords.class);
 		// set the env variables
-		JsonObject input = Json.createObjectBuilder().add("Command", "echo $Password").add("Properties_As_Env", true)
+		JsonObject input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", true)
 				.build();
 		Output<JsonObject> output = ctx.run("ExecuteBash", input.toString());
 
 		assertTrue(output.getPayload().getString("stdout").startsWith("glop"));
 
 		// DO NOT set the env variables
-		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Properties_As_Env", false)
+		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", false)
+				.build();
+		output = ctx.run("ExecuteBash", input.toString());
+
+		assertTrue(output.getPayload().getString("stdout").equals("\n"));
+
+		// with no properties - Pass_Properties_As_Env_Variables = false
+		ctx = old_ctx;
+
+		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", false)
+				.build();
+		output = ctx.run("ExecuteBash", input.toString());
+
+		assertTrue(output.getPayload().getString("stdout").equals("\n"));
+
+		// with no properties - Pass_Properties_As_Env_Variables = true
+		input = Json.createObjectBuilder().add("Command", "echo $Password").add("Pass_Properties_As_Env_Variables", true)
 				.build();
 		output = ctx.run("ExecuteBash", input.toString());
 


### PR DESCRIPTION
This change request adds a flag to pass all the non-specials properties to the executable as environment variables