### PR TITLE
Fixing wrong zip file name

### DIFF
--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/FileSystemKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/FileSystemKeywords.java
@@ -326,10 +326,10 @@ public class FileSystemKeywords extends AbstractEnhancedKeyword {
             description="Keyword used to zip a folder.")
     public void Zip_file() {
         String folderName = input.getString("Folder");
-        String zip = input.getString("Destination", folderName + ".zip");
+        File folder = new File(folderName).getAbsoluteFile();
 
-        File folder = new File(folderName);
-        File zipFile = new File(zip);
+        String zip = input.getString("Destination", folder.getName() + ".zip");
+        File zipFile = new File(zip).getAbsoluteFile();
 
         if (!folder.exists()) {
             output.setBusinessError("Folder \"" + folderName + "\" do not exist.");
@@ -346,6 +346,7 @@ public class FileSystemKeywords extends AbstractEnhancedKeyword {
 
         try {
             FileHelper.zip(folder, zipFile);
+            output.add("Destination",zipFile.getCanonicalPath());
         } catch (Exception e) {
             output.setBusinessError(
                     "Exception when zipping \"" + folderName + "\". Error message was: \"" + e.getMessage() + "\"");

--- a/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/FileSystemKeywords.java
+++ b/keywords/java/step-library-kw-system/src/main/java/ch/exense/step/library/kw/system/FileSystemKeywords.java
@@ -328,7 +328,7 @@ public class FileSystemKeywords extends AbstractEnhancedKeyword {
         String folderName = input.getString("Folder");
         File folder = new File(folderName).getAbsoluteFile();
 
-        String zip = input.getString("Destination", folder.getName() + ".zip");
+        String zip = input.getString("Destination", folder.getAbsolutePath() + ".zip");
         File zipFile = new File(zip).getAbsoluteFile();
 
         if (!folder.exists()) {

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
@@ -112,6 +112,14 @@ public class FileSystemKeywordsTest {
 
 		System.out.println(output.getPayload());
 		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/test-classes.zip"));
+
+		// test if Folder contains relative paths
+		input = Json.createObjectBuilder().add("Folder", path+"/../../target").build();
+
+		output = ctx.run("Zip_file", input.toString());
+
+		System.out.println(output.getPayload());
+		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/target.zip"));
 	}
 	
 	@Test

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
@@ -97,11 +97,21 @@ public class FileSystemKeywordsTest {
 	public void test_zip() throws Exception {
 		String path = new File(getClass().getClassLoader().getResource("package.json").getFile()).getParent();
 
-		JsonObject input = Json.createObjectBuilder().add("Folder", path).add("Destination", path+ File.separator +".." + File.separator + "test_zip.zip").build();
+		JsonObject input = Json.createObjectBuilder().add("Folder", path)
+				.add("Destination", path+ File.separator +".." + File.separator + "test_zip.zip").build();
 		
 		Output<JsonObject> output = ctx.run("Zip_file", input.toString());
 		
 		System.out.println(output.getPayload());
+		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/test_zip.zip"));
+
+		// test if Folder end with a "/"
+		input = Json.createObjectBuilder().add("Folder", path+"/").build();
+
+		output = ctx.run("Zip_file", input.toString());
+
+		System.out.println(output.getPayload());
+		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/test-classes.zip"));
 	}
 	
 	@Test

--- a/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
+++ b/keywords/java/step-library-kw-system/src/test/java/ch/exense/step/library/kw/system/FileSystemKeywordsTest.java
@@ -103,7 +103,9 @@ public class FileSystemKeywordsTest {
 		Output<JsonObject> output = ctx.run("Zip_file", input.toString());
 		
 		System.out.println(output.getPayload());
-		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/test_zip.zip"));
+		String destination = output.getPayload().getString("Destination");
+		Assert.assertTrue(destination.endsWith("/test_zip.zip"));
+		Assert.assertTrue(new File(destination).exists());
 
 		// test if Folder end with a "/"
 		input = Json.createObjectBuilder().add("Folder", path+"/").build();
@@ -111,7 +113,10 @@ public class FileSystemKeywordsTest {
 		output = ctx.run("Zip_file", input.toString());
 
 		System.out.println(output.getPayload());
-		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/test-classes.zip"));
+
+		destination = output.getPayload().getString("Destination");
+		Assert.assertTrue(destination.endsWith("/test-classes.zip"));
+		Assert.assertTrue(new File(destination).exists());
 
 		// test if Folder contains relative paths
 		input = Json.createObjectBuilder().add("Folder", path+"/../../target").build();
@@ -119,7 +124,9 @@ public class FileSystemKeywordsTest {
 		output = ctx.run("Zip_file", input.toString());
 
 		System.out.println(output.getPayload());
-		Assert.assertTrue(output.getPayload().getString("Destination").endsWith("/target.zip"));
+		destination = output.getPayload().getString("Destination");
+		Assert.assertTrue(destination.endsWith("/target.zip"));
+		Assert.assertTrue(new File(destination).exists());
 	}
 	
 	@Test


### PR DESCRIPTION
When calling the Zip_File keyword with a Folder containing an ending "/", the created zip file is wrong ".../my_folder/.zip"
This merge request will create the file ".../my_folder.zip" instead

Also added is the output parameter Destination containing the absolute path of the zip file